### PR TITLE
Memory leak fix

### DIFF
--- a/src/llist.c
+++ b/src/llist.c
@@ -103,11 +103,11 @@ void insert_optimized(struct llist *llst, struct cell *c)
     struct lcell *current_lcell;
     struct lcell *new_lcell;
     struct list *lst;
-    lst = new_list();
     // CAS 1: la lliste est vide
     if (llst->head == NULL)
     {
         // printf("lliste vide\n");
+        lst = new_list();
         current_lcell = make_lcell(lst, c);
         llst->head = current_lcell;
         return;
@@ -115,6 +115,7 @@ void insert_optimized(struct llist *llst, struct cell *c)
     // CAS 2: insertion d'une lcell dans une lliste (ajout d'une lettre au début de l'index)
     if (compare_lcells(llst->head, c) > 0)
     {
+        lst = new_list();
         current_lcell = make_lcell(lst, c);
         current_lcell->next = llst->head;
         llst->head = current_lcell;
@@ -136,6 +137,7 @@ void insert_optimized(struct llist *llst, struct cell *c)
         }
         if (compare_lcells(current_lcell->next, c) > 0)
         {
+            lst = new_list();
             new_lcell = make_lcell(lst, c);
             new_lcell->next = current_lcell->next;
             current_lcell->next = new_lcell;
@@ -155,6 +157,7 @@ void insert_optimized(struct llist *llst, struct cell *c)
         // printf("Ajout dans current_lcell n°%d\n", debug_counter++);
         return;
     }
+    lst = new_list();
     current_lcell->next = make_lcell(lst, c);
     // printf("Ajout d'une lcell à la fin de l'index : ");
     // print_lcell(current_lcell->next);


### PR DESCRIPTION
Hello,
Si tu regardes le résultat de valgrind, il te pointe dans la bonne direction !

```
❯ valgrind --leak-check=full -s bin/womc data/test.txt
==129561== Memcheck, a memory error detector
==129561== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==129561== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==129561== Command: bin/womc data/test.txt
==129561== 
Méthode 2 :
==129561== 
==129561== HEAP SUMMARY:
==129561==     in use at exit: 72 bytes in 9 blocks
==129561==   total heap usage: 162 allocs, 153 frees, 8,650 bytes allocated
==129561== 
==129561== 72 bytes in 9 blocks are definitely lost in loss record 1 of 1
==129561==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==129561==    by 0x10933E: new_list (list.c:8)
==129561==    by 0x109C10: insert_optimized (llist.c:106)
==129561==    by 0x109E38: load_file_optimized (llist.c:182)
==129561==    by 0x10992A: main (main.c:123)
==129561== 
==129561== LEAK SUMMARY:
==129561==    definitely lost: 72 bytes in 9 blocks
==129561==    indirectly lost: 0 bytes in 0 blocks
==129561==      possibly lost: 0 bytes in 0 blocks
==129561==    still reachable: 0 bytes in 0 blocks
==129561==         suppressed: 0 bytes in 0 blocks
==129561== 
==129561== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

Le problème vient de la ligne 106 dans `llist.c`. Tu crées (et alloue !!!) la nouvelle sous-liste à chaque étape alors que dans certains cas elle n'est pas utilisée (cas 1 et 4). En gardant le pointeur au même endroit et en allouant la liste seulement aux moments ou c'est vraiment nécessaire on n'a plus de fuites !

Bien joué en tout cas !